### PR TITLE
Changed chat_grey to normal background

### DIFF
--- a/Sweetycon.json
+++ b/Sweetycon.json
@@ -148,6 +148,6 @@
     "STATUS_YELLOW": "#f164dc"
   },
   "unsafe_colors": {
-    "CHAT_GREY": "#212027"
+    "CHAT_GREY": "#181c28"
   }
 }


### PR DESCRIPTION
Changed chat_grey to normal background to fix grey segment: https://media.discordapp.net/attachments/950979289531162666/1047041898763792475/DD6464EA-3299-4184-827F-3EBE6AC6C934.jpg